### PR TITLE
Use Data Connect Authorize V1 API

### DIFF
--- a/src/groovy/smarthome/api/DataConnectApi.groovy
+++ b/src/groovy/smarthome/api/DataConnectApi.groovy
@@ -21,14 +21,12 @@ class DataConnectApi {
 		"dev": [
 			authorize: "https://gw.hml.api.enedis.fr",
 			token: "https://gw.hml.api.enedis.fr",
-			metric: "https://gw.hml.api.enedis.fr",
-			redirect_uri: "redirect_uri"
+			metric: "https://gw.hml.api.enedis.fr"
 		],
 		"prod": [
-			authorize: "https://espace-client-particuliers.enedis.fr",
+			authorize: "https://mon-compte-particulier.enedis.fr",
 			token: "https://gw.prd.api.enedis.fr",
-			metric: "https://gw.prd.api.enedis.fr",
-			redirect_uri: "redirect_URI"
+			metric: "https://gw.prd.api.enedis.fr"
 		]
 	]
 
@@ -48,12 +46,11 @@ class DataConnectApi {
 	 * @return
 	 */
 	String authorize_uri() {
-		String url = "${URLS[(grailsApplication.config.enedis.env)].authorize}/group/espace-particuliers/consentement-linky/oauth2/authorize"
+		String url = "${URLS[(grailsApplication.config.enedis.env)].authorize}/dataconnect/v1/oauth2/authorize"
 		url += "?client_id=${grailsApplication.config.enedis.client_id}"
 		url += "&duration=P3Y"
 		url += "&response_type=code"
 		url += "&state=${grailsApplication.config.enedis.state}"
-		url += "&${URLS[(grailsApplication.config.enedis.env)].redirect_uri}=${grailsApplication.config.enedis.redirect_uri}"
 		return url
 	}
 


### PR DESCRIPTION
Legacy one will be deactivated on 2020-09-12.

<https://datahub-enedis.fr/data-connect/ressources/migrer-votre-application/>
<https://datahub-enedis.fr/data-connect/support/forum/topic/authorize-v1/>
<https://datahub-enedis.fr/data-connect/documentation/authorize-v1/>

It seems returned errors has changed a bit, I did not check this yet.